### PR TITLE
Supression tests recuit

### DIFF
--- a/Sudoku.Benchmark/Sudoku.Benchmark.csproj
+++ b/Sudoku.Benchmark/Sudoku.Benchmark.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Sudoku.GabrielOscar\Sudoku.GabrielOscar.csproj" />
     <ProjectReference Include="..\Sudoku.Shared\Sudoku.Shared.csproj" />
     <ProjectReference Include="..\Sudoku.Backtracking\Sudoku.Backtracking.csproj" />
+    <ProjectReference Include="..\Sudoku.SMTZ3\Sudoku.SMTZ3.csproj" />
     <ProjectReference Include="..\Sudoku.YicesSolvers\Sudoku.YicesSolvers.csproj" />
     <ProjectReference Include="..\Sudoku.Z3Solvers\Sudoku.Z3Solvers.csproj" />
     <ProjectReference Include="..\Sudoku.recuit_simule\Sudoku.recuit_simule.csproj" />

--- a/Sudoku.ChocoSolvers/ChocoDomOverWDegRefSearchSolver.cs
+++ b/Sudoku.ChocoSolvers/ChocoDomOverWDegRefSearchSolver.cs
@@ -1,0 +1,25 @@
+﻿using org.chocosolver.solver;
+using org.chocosolver.solver.constraints;
+using org.chocosolver.solver.search.strategy;
+using org.chocosolver.solver.variables;
+using Sudoku.Shared;
+
+namespace Sudoku.ChocoSolvers;
+
+public class ChocoDomOverWDegRefSearchSolver : ChocoSimpleSolver
+{
+	public override Solver GetSolver(Model model, IntVar[][] cellVariables, List<Constraint> constraints)
+	{
+		var solver = model.getSolver();
+			
+		foreach (var constraint in constraints)
+		{
+			constraint.post();
+		}
+		// cf https://choco-solver.org/docs/solving/strategies/
+
+		solver.setSearch(Search.domOverWDegRefSearch(cellVariables.Flatten()));
+
+		return solver;
+	}
+}

--- a/Sudoku.ChocoSolvers/ChocoSolverPython.cs
+++ b/Sudoku.ChocoSolvers/ChocoSolverPython.cs
@@ -1,8 +1,0 @@
-using System;
-
-namespace Sudoku.ChocoSolvers;
-
-public class ChocoSolverPython
-{
-
-}

--- a/Sudoku.ChocoSolvers/Sudoku.ChocoSolvers.csproj
+++ b/Sudoku.ChocoSolvers/Sudoku.ChocoSolvers.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IKVM" Version="8.11.0-pre.2" />
+    <PackageReference Include="IKVM" Version="8.10.3" />
     <PackageReference Include="IKVM.Image" Version="8.11.0-pre.2" />
     <PackageReference Include="IKVM.Image.JDK" Version="8.11.0-pre.2" />
     <PackageReference Include="IKVM.Image.JRE" Version="8.11.0-pre.2" />
@@ -20,5 +20,19 @@
   <ItemGroup>
     <ProjectReference Include="..\Sudoku.Shared\Sudoku.Shared.csproj" />
   </ItemGroup>
+
+
+  <ItemGroup>
+    <Reference Include="IKVM">
+      <HintPath>$(NuGetPackageRoot)\ikvm\8.10.3\lib\IKVM.dll</HintPath>
+    </Reference>
+    <Reference Include="ChocoSolver">
+      <HintPath>choco-solver.jar</HintPath>
+      <AssemblyName>ChocoSolver</AssemblyName>
+      <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
+    </Reference>
+  </ItemGroup>
+
 
 </Project>

--- a/Sudoku.SMTZ3/SMTSimpleZ3.cs
+++ b/Sudoku.SMTZ3/SMTSimpleZ3.cs
@@ -1,0 +1,11 @@
+﻿using Sudoku.Shared;
+
+namespace Sudoku.SMTZ3;
+
+public class SMTSimpleZ3 : ISudokuSolver
+{
+    public SudokuGrid Solve(SudokuGrid s)
+    {
+        return s;
+    }
+}

--- a/Sudoku.SMTZ3/SMTSimpleZ3.cs
+++ b/Sudoku.SMTZ3/SMTSimpleZ3.cs
@@ -1,11 +1,77 @@
 ﻿using Sudoku.Shared;
+using Microsoft.Z3;
 
-namespace Sudoku.SMTZ3;
-
-public class SMTSimpleZ3 : ISudokuSolver
+namespace Sudoku.SMTZ3
 {
-    public SudokuGrid Solve(SudokuGrid s)
+    public class SMTSimpleZ3 : ISudokuSolver
     {
-        return s;
+        public SudokuGrid Solve(SudokuGrid s)
+        {
+            using (var context = new Context())
+            {
+                var solver = context.MkSolver();
+                IntExpr[,] cells = new IntExpr[9, 9];
+
+                // Create variables for each cell
+                for (int i = 0; i < 9; i++)
+                {
+                    for (int j = 0; j < 9; j++)
+                    {
+                        cells[i, j] = (IntExpr)context.MkIntConst($"cell_{i}_{j}");
+                        solver.Assert(context.MkAnd(context.MkLe(context.MkInt(1), cells[i, j]), context.MkLe(cells[i, j], context.MkInt(9))));
+                    }
+                }
+
+                // Add constraints for the initial grid
+                for (int i = 0; i < 9; i++)
+                {
+                    for (int j = 0; j < 9; j++)
+                    {
+                        if (s.Cells[i, j] != 0)
+                        {
+                            solver.Assert(context.MkEq(cells[i, j], context.MkInt(s.Cells[i, j])));
+                        }
+                    }
+                }
+
+                // Add constraints for rows, columns, and 3x3 subgrids
+                for (int i = 0; i < 9; i++)
+                {
+                    solver.Assert(context.MkDistinct(cells[i, 0], cells[i, 1], cells[i, 2], cells[i, 3], cells[i, 4], cells[i, 5], cells[i, 6], cells[i, 7], cells[i, 8]));
+                    solver.Assert(context.MkDistinct(cells[0, i], cells[1, i], cells[2, i], cells[3, i], cells[4, i], cells[5, i], cells[6, i], cells[7, i], cells[8, i]));
+                }
+
+                for (int i = 0; i < 3; i++)
+                {
+                    for (int j = 0; j < 3; j++)
+                    {
+                        solver.Assert(context.MkDistinct(
+                            cells[i * 3, j * 3], cells[i * 3, j * 3 + 1], cells[i * 3, j * 3 + 2],
+                            cells[i * 3 + 1, j * 3], cells[i * 3 + 1, j * 3 + 1], cells[i * 3 + 1, j * 3 + 2],
+                            cells[i * 3 + 2, j * 3], cells[i * 3 + 2, j * 3 + 1], cells[i * 3 + 2, j * 3 + 2]
+                        ));
+                    }
+                }
+
+                // Check if the solution exists
+                if (solver.Check() == Status.SATISFIABLE)
+                {
+                    Model model = solver.Model;
+                    SudokuGrid solvedGrid = new SudokuGrid();
+                    for (int i = 0; i < 9; i++)
+                    {
+                        for (int j = 0; j < 9; j++)
+                        {
+                            solvedGrid.Cells[i, j] = ((IntNum)model.Evaluate(cells[i, j])).Int;
+                        }
+                    }
+                    return solvedGrid;
+                }
+                else
+                {
+                    throw new Exception("No solution found");
+                }
+            }
+        }
     }
 }

--- a/Sudoku.SMTZ3/Sudoku.SMTZ3.csproj
+++ b/Sudoku.SMTZ3/Sudoku.SMTZ3.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sudoku.Shared\Sudoku.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Sudoku.SMTZ3/Sudoku.SMTZ3.csproj
+++ b/Sudoku.SMTZ3/Sudoku.SMTZ3.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\Sudoku.Shared\Sudoku.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Z3" Version="4.12.2" />
+  </ItemGroup>
+
 </Project>

--- a/Sudoku.recuit_simule/recuit_alpha_v2.cs
+++ b/Sudoku.recuit_simule/recuit_alpha_v2.cs
@@ -6,7 +6,7 @@ using Sudoku.Shared;
 
 namespace Sudoku.recuit_simule
 {
-    public class recuit_alpha_v2: ISudokuSolver
+    public class recuit_alpha_v2
     {
         private static readonly Random rand = new Random();
 

--- a/Sudoku.recuit_simule/recuit_temperature_v2.cs
+++ b/Sudoku.recuit_simule/recuit_temperature_v2.cs
@@ -6,7 +6,7 @@ using Sudoku.Shared;
 
 namespace Sudoku.recuit_simule
 {
-    public class recuit_temperature_v2: ISudokuSolver
+    public class recuit_temperature_v2
     {
         private static readonly Random rand = new Random();
 

--- a/Sudoku.sln
+++ b/Sudoku.sln
@@ -16,9 +16,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sudoku.YicesSolvers", "Sudoku.YicesSolvers\Sudoku.YicesSolvers.csproj", "{40A429AA-9ABC-4604-B808-494681B8279C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sudoku.GabrielOscar", "Sudoku.GabrielOscar\Sudoku.GabrielOscar.csproj", "{2D99BFAF-A85F-4641-B3B7-CBCCF3CC6C89}"
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sudoku.recuit_simule", "Sudoku.recuit_simule\Sudoku.recuit_simule.csproj", "{5C0CBA12-B520-4202-BB10-DF3F02677DC9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "sudoku.PyGadSolver", "sudoku.PyGadSolver\sudoku.PyGadSolver.csproj", "{AE206AB6-773F-4031-B7FC-8797D2948E90}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sudoku.SMTZ3", "Sudoku.SMTZ3\Sudoku.SMTZ3.csproj", "{E32008A6-12DE-42C7-B8D2-7B991EF5A508}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -62,6 +63,10 @@ Global
 		{AE206AB6-773F-4031-B7FC-8797D2948E90}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AE206AB6-773F-4031-B7FC-8797D2948E90}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AE206AB6-773F-4031-B7FC-8797D2948E90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E32008A6-12DE-42C7-B8D2-7B991EF5A508}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E32008A6-12DE-42C7-B8D2-7B991EF5A508}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E32008A6-12DE-42C7-B8D2-7B991EF5A508}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E32008A6-12DE-42C7-B8D2-7B991EF5A508}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
OK pour ta dernière PR, plusieurs remarques:

- Tu aurais du transformer ton projet en application de Console pour conduire tes tests, tu ne peux pas vraiment lancer une expérience dans le cadre d'un solver qui va apparaître dans le menu et surtout polluer le benchmark. Du coup j'ai fait sauter l'interface de tes 2 classes d'expériences pour les enlever du menu et libérer les Benchmarks. A la rigueur maintenant que tu les as faites tourner, tu pourrais inclure les fichiers de résultat.

- Tu devrais t'appuyer sur l'héritage ou la composition pour mutualiser ton code. Là on ne sais pas trop entre tes classes ce qui change et ce qui est recopié. En l'occurence, une fois ton expérience conduite, tu pourras nous dériver une poignée de solvers avec des paramètres différents hérités d'une classe de base abstraite configurable en température et en alpha. Comme ça tout le monde pourra constater la différence de perfs sans que le benchmark soit complètement saturé par tes expériences.